### PR TITLE
Fixes ti and tu. Also sya, syu, sho.

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -72,6 +72,10 @@ var hiraganaTests = []testPair{
 	// Consonant modifier (tsu).
 	{"tcho", "っちょ"},
 	{"atcho", "あっちょ"},
+	// Plosive
+	{"shuppatu", "しゅっぱつ"},
+	{"syuppatu", "しゅっぱつ"},
+	{"syuppatsu", "しゅっぱつ"},
 	// Leave existing kana alone.
 	{"カタカナ日本語カタカナひらがなカタカナ\n", "カタカナ日本語カタカナひらがなカタカナ\n"},
 }

--- a/hiragana.go
+++ b/hiragana.go
@@ -173,8 +173,8 @@ var twoH = map[string]string{
 	"te": "て",
 	"to": "と",
 
-	"ti": "てぃ",
-	"tu": "とぅ",
+	"ti": "ち",
+	"tu": "つ",
 
 	"di": "でぃ",
 	"du": "どぅ",
@@ -260,6 +260,9 @@ var threeH = map[string]string{
 	"sha": "しゃ",
 	"shu": "しゅ",
 	"sho": "しょ",
+	"sya": "しゃ",
+	"syu": "しゅ",
+	"syo": "しょ",
 
 	"chi": "ち",
 	"tsu": "つ",


### PR DESCRIPTION
ti is ち not てぃ.
tu is つ not とぅ.
sya is しゃ.
syu is しゅ.
syo is しょ.
